### PR TITLE
Freesound login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN mkdir /code
 ADD requirements.txt /code
 
 WORKDIR /code
-RUN pip install --no-cache -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ADD . /code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     stop_signal: SIGINT
     volumes:
       - .:/code
-      - /Users/ffont/Data/FSL10K0:/static/FSL10K
+      - ./static/FSL10K:/static/FSL10K

--- a/getsounds.py
+++ b/getsounds.py
@@ -3,6 +3,7 @@ import glob
 import json
 
 default_N_assign_more_sounds = 10
+PATH_TO_FSL10K = "/static/FSL10K"
 
 def compile_annotated_sounds(annotations_path):
     annotated_sounds = {}
@@ -21,11 +22,15 @@ def compile_annotated_sounds(annotations_path):
 
     return annotated_sounds
 
-def collect_assigned_sounds(sound_id_user):
+def collect_assigned_sounds():
     assigned_sounds = []
-    for key in sound_id_user.keys():
-        for sound in sound_id_user[key]:
-            assigned_sounds.append(sound)
+    #for key in sound_id_user.keys():
+    user_path = os.path.join(PATH_TO_FSL10K, 'annotators/')
+    for user_file in os.listdir(user_path):
+        if user_file.endswith(".json"):
+            assigned_user_sounds = json.load(open(os.path.join(user_path,user_file), 'rb')) 
+            for sound in assigned_user_sounds:
+                assigned_sounds.append(sound)
 
     return assigned_sounds
 
@@ -86,7 +91,7 @@ def discard_packs(all_sound_ids,metadata):
 
 
 
-def select_relevant_sounds(annotations_path, metadata, genre_metadata, all_sound_ids, sound_id_user, N=default_N_assign_more_sounds):
+def select_relevant_sounds(annotations_path, metadata, genre_metadata, all_sound_ids, N=default_N_assign_more_sounds):
 
     sounds_annotated = compile_annotated_sounds(annotations_path)
 
@@ -113,7 +118,7 @@ def select_relevant_sounds(annotations_path, metadata, genre_metadata, all_sound
     genre_sounds = collect_genres(sounds_annotated)
     sounds_to_rate = discard_packs(all_sound_ids,metadata)
     sound_irrelevance_list = []
-    assigned_sounds = collect_assigned_sounds(sound_id_user)
+    assigned_sounds = collect_assigned_sounds()
 
     for sound in sounds_to_rate:
         num_annotated = 0

--- a/getsounds.py
+++ b/getsounds.py
@@ -4,6 +4,9 @@ import json
 
 default_N_assign_more_sounds = 10
 PATH_TO_FSL10K = "/static/FSL10K"
+PATH_TO_AC_ANALYSIS = os.path.join(PATH_TO_FSL10K, 'ac_analysis/')
+PATH_TO_METADATA = os.path.join(PATH_TO_FSL10K, 'fs_analysis/')
+
 
 def compile_annotated_sounds(annotations_path):
     annotated_sounds = {}
@@ -137,7 +140,14 @@ def select_relevant_sounds(annotations_path, metadata, genre_metadata, all_sound
         
         gen_importance = genre_importance(genre_metadata.get(sound,[]), genre_sounds)
         irrelevance = (num_annotated+num_assigned)*anno_weight + num_author*auth_weight + num_pack*pack_weight + gen_importance*genre_weight
-        sound_irrelevance_list.append((sound,irrelevance))
+
+        ac_analysis_filename = metadata[sound]["preview_url"]
+        base_name = ac_analysis_filename[ac_analysis_filename.rfind("/"):ac_analysis_filename.find("-hq")]
+        ac_analysis_filename =  base_name + "_analysis.json"
+
+
+        if os.path.exists(PATH_TO_AC_ANALYSIS + ac_analysis_filename):
+            sound_irrelevance_list.append((sound,irrelevance))
     
     sound_irrelevance_sorted = sorted(sound_irrelevance_list, key=lambda x: x[1])
     sound_irrelevance_ids = [lis[0] for lis in sound_irrelevance_sorted]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==1.1.1
+requests-oauthlib==1.3.0
 Flask-HTTPAuth==3.3.0
 uwsgi

--- a/templates/index.html
+++ b/templates/index.html
@@ -369,7 +369,7 @@
                     id: '{{sound_id}}'
                 }
                 $.ajax({
-                    url: '/fslannotator/annotate',
+                    url: '/fslannotator/annotate/',
                     type: 'post',
                     dataType: 'json',
                     contentType: 'application/json',

--- a/templates/index.html
+++ b/templates/index.html
@@ -369,13 +369,13 @@
                     id: '{{sound_id}}'
                 }
                 $.ajax({
-                    url: '/fslannotator/',
+                    url: '/fslannotator/annotate',
                     type: 'post',
                     dataType: 'json',
                     contentType: 'application/json',
                     success: function (data) {
                         console.log(data);
-                        window.location.replace("/fslannotator/?p={{page+1}}");
+                        window.location.replace("/fslannotator/annotate/?p={{page+1}}");
                     },
                     data: JSON.stringify(data)
                 });

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -9,11 +9,9 @@
         </style>
     </head>
     <body>
-        <p>You do not have sounds assigned to you!</p>
-        {% if enable_auto_assign_annotations %}
-        <p>Want some?
-        <a href="/fslannotator/assign">Assign {{N}} sounds!</a>
+        <p>Welcome to the Freesound Loop Annotator!</p>
+        <p>If you want to contribute to our work,
+        <a href="/fslannotator/login">login</a> with your Freesound Account!
         </p>
-        {% endif %}
     </body>
 </html>


### PR DESCRIPTION
In order to make the Freesound Loop Annotator public, I added the following features:

- Replaced the previous authentication with login from Freesound
- Added a landing page
- Moved the annotating webpage from `fslannotator/` to `flsannotator/annotate/`
- Changed the number of assigned sounds from 125 to 10
- Added an extra test on `getsounds.py` to make sure it only assigns sounds which have an AudioCommons analysis
- `users.json` which had the list of users is now replaced by the annotators folder

To migrate it to the server we have to:
- Upload the annotators folder which replaces the old `metadata_sound_ids_list_username.json`
